### PR TITLE
git hash and tag support

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ markdown files and put in their place one line reading `{docugen}`.
 ```python
 python generate.py \
   --template_file path/to/_SUMMARY.md \
-  --git_hash 7bbc4a4eac8eeb2bf37a62ce519e0de61c67eadf \
+  --commit_id 7bbc4a4eac8eeb2bf37a62ce519e0de61c67eadf \
   --output_dir path/to/gitbook
 ```
 

--- a/cli.py
+++ b/cli.py
@@ -206,7 +206,7 @@ def pre_process(help_page: str) -> str:
     for idx, line in enumerate(page_splits):
         # Capture the starting white spaces of the line
         white_space = re_space.findall(line)
-        num_white_space = len(white_space) if white_space else 0
+        num_white_space = len(white_space[0]) if white_space else 0
         if num_white_space > 2:
             # Can be either
             # - wrapped description

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+wandb
+astor
+dataclasses


### PR DESCRIPTION
With this PR:
- We can now use `version` and `commit id` to link the source code.
- Added asserts for `version` which checks the local system package version and compares with the argument passed.
```python
if "." in commit_id:
  # commit_id is a version
  wandb_version = f"v{wandb.__version__}"
  assert (
    wandb_version == commit_id
  ), f"git version does not match wandb version {wandb_version}"
```
- Fixed a small error in the CLI generation process. The first element of `white_space` had to be considered to count the number of white_spaces.
```python
num_white_space = len(white_space[0]) if white_space else 0
```