### PR TITLE
[DOCS-162]

### DIFF
--- a/docugen/parser.py
+++ b/docugen/parser.py
@@ -292,7 +292,7 @@ AUTO_REFERENCE_RE = re.compile(
     r"""
     (?P<brackets>\[.*?\])                    # find characters inside '[]'
     |
-    `(?P<backticks>[\w\(\[\)\]\{\}.,=\s\*]+?)` # or find characters and star inside '``'
+    `(?P<backticks>[\w\(\[\)\]\{\}.,=\s\*\?\#]+?)` # find characters inside '``'
     """,
     flags=re.VERBOSE,
 )


### PR DESCRIPTION
## Changes:
- Modification of `AUTO_REFERENCE_RE` to include `*` inside on backticks. The problem raised due to the following docstring:
    ```python
    You can filter by `config.*`, `summary.*`, `state`, `entity`, `createdAt`, etc.
    ```
    Here one can see that the `config.*` needs to be captured. The modification in the regex does just that.

## After regex capture:
![image](https://user-images.githubusercontent.com/36856589/117754119-54c3de00-b237-11eb-8544-414c5a0c094b.png)
