### PR TITLE
[DOCS-168] keras docs reformat

### DIFF
--- a/generate.py
+++ b/generate.py
@@ -25,6 +25,7 @@ DIRNAMES_TO_TITLES = {
     "python": "Python Library",
     "integrations": "Integrations",
     "java": r"Java Library \[Beta\]",
+    "keras": "Keras",
 }
 
 SKIPS = ["app", "java"]

--- a/library.py
+++ b/library.py
@@ -200,3 +200,10 @@ def configure_doc_hiding():
         doc_controls.decorate_all_class_attributes(
             decorator=deco, cls=cls, skip=["__init__"]
         )
+
+    # For keras
+    from tensorflow import keras
+    deco = doc_controls.do_not_doc_in_subclasses
+    doc_controls.decorate_all_class_attributes(
+            decorator=deco, cls=keras.callbacks.Callback, skip=["__init__", "set_model", "set_params"]
+        )


### PR DESCRIPTION
[DOCS-168](https://wandb.atlassian.net/browse/DOCS-168)

In this PR:
- [x] Capitalize Keras in the sidebar.
    The implementation is done in the `generate.py` file where the `dirname mapping` has been changed.
- [x] Remove all of the methods that we don't implement – ie, everything but set_model and set_params.
    The `keras.callbacks.Callback` subclasses are hidden.