### PR TITLE
html -> md init

### DIFF
--- a/docugen/parser.py
+++ b/docugen/parser.py
@@ -490,7 +490,7 @@ class ReferenceResolver(object):
         # Found a '``' group.
         if match.group(2):
             string = match.group("backticks")
-            string = "<code>" + string + "</code>"
+            string = "`" + string + "`"
             return string
 
         return match.group(0)
@@ -510,37 +510,11 @@ def _pairs(items):
 
 
 # Don't change the width="214px" without consulting with the devsite-team.
-TABLE_TEMPLATE = textwrap.dedent(
-    """
-  <!-- Tabular view -->
-  <table>
-  <tr><th>{title}</th></tr>
-  {text}
-  {items}
-  </table>
-  """
-)
+TABLE_TEMPLATE = """\n| {title} |  |\n| :--- | :--- |\n{text}{items}"""
 
-ITEMS_TEMPLATE = textwrap.dedent(
-    """\
-  <tr>
-  <td>
-  {name}{anchor}
-  </td>
-  <td>
-  {description}
-  </td>
-  </tr>"""
-)
+ITEMS_TEMPLATE = """|  {name}{anchor} |  {description} |\n"""
 
-TEXT_TEMPLATE = textwrap.dedent(
-    """\
-  <tr>
-  <td>
-  {text}
-  </td>
-  </tr>"""
-)
+TEXT_TEMPLATE = """|  {text} |\n"""
 
 
 class TitleBlock(object):
@@ -615,6 +589,10 @@ class TitleBlock(object):
 
         text = self.text.strip()
         if text:
+            # text is a para with \n
+            # we need to transform the para
+            # into a single line for table formatting
+            text = " ".join(text.split())
             text = TEXT_TEMPLATE.format(text=text)
             text = self._INDENTATION_REMOVAL_RE.sub(r"\2", text)
 
@@ -626,8 +604,12 @@ class TitleBlock(object):
                 continue
             else:
                 description = description.strip()
+            # description is a para with \n
+            # we need to transform the para
+            # into a single line for table formatting
+            description = " ".join(description.split())
             item_table = ITEMS_TEMPLATE.format(
-                name=f"<code>{name}</code>", anchor="", description=description
+                name=f"`{name}`", anchor="", description=description
             )
             item_table = self._INDENTATION_REMOVAL_RE.sub(r"\2", item_table)
             items.append(item_table)
@@ -1253,7 +1235,7 @@ def generate_signature(
         return_type = formatter.format_return(return_anno)
     else:
         return_type = "None"
-
+    all_args_list = list(map(lambda x: x.replace('&#x27;', '"'), all_args_list))
     return _SignatureComponents(
         arguments=all_args_list,
         arguments_typehint_exists=arguments_typehint_exists,

--- a/docugen/pretty_docs.py
+++ b/docugen/pretty_docs.py
@@ -515,23 +515,23 @@ def _build_signature(
 
     full_signature = str(obj_info.signature)
 
-    parts = ["<pre>"]
+    parts = ["```python\n"]
 
     if hasattr(obj_info, "decorators"):
         parts.extend(
             [
-                f"<code>@{dec}</code>\n"
+                f"@{dec}\n"
                 for dec in obj_info.decorators
                 if dec in DECORATOR_ALLOWLIST
             ]
         )
 
     if type_alias:
-        parts.append(f"<code>{obj_name} = {full_signature}\n")
+        parts.append(f"{obj_name} = {full_signature}\n")
     else:
         obj_name = obj_name.split(".")[-1]
-        parts.append(f"<code>{obj_name}{full_signature}")
-    parts.append("</code></pre>\n\n")
+        parts.append(f"{obj_name}{full_signature}\n")
+    parts.append("```\n\n")
 
     return "".join(parts)
 
@@ -549,11 +549,7 @@ _TABLE_TEMPLATE = textwrap.dedent(
     {table_footer}"""
 )
 
-_TABLE_LINK_TEMPLATE = textwrap.dedent(
-    """\
-  [![](https://www.tensorflow.org/images/GitHub-Mark-32px.png)View source on GitHub]({url})
-  """
-)
+_TABLE_LINK_TEMPLATE = """[![](https://www.tensorflow.org/images/GitHub-Mark-32px.png)View source on GitHub]({url})"""
 
 
 def _top_source_link(location):
@@ -579,7 +575,7 @@ def _top_source_link(location):
 
 def _small_source_link(location):
     """Returns a small source link."""
-    template = '<a target="_blank" href="{url}">View source</a>\n\n'
+    template = '[View source]({url})\n\n'
 
     if not location.url:
         return ""


### PR DESCRIPTION
Jira tickets
--
[DOCS-145](https://wandb.atlassian.net/browse/DOCS-145)
[DOCS-169](https://wandb.atlassian.net/browse/DOCS-169)

Description:
---
- [x] Turn the html table to markdown tables.
  - Turn `<table>` into `|  |  |`
  - Turning paragraphs (with `\n`) to single lines text so that the tables don't break.
- [x] Adding Python styling to our type signatures.
  - Replacing `&#x27;` to `"`
- [ ] Align the `\n` of our generated docs and gitbook docs.

Gitbook
---

[Gitbook Version](https://arig23498.gitbook.io/aritra-documentation/~/revisions/-MaD1RIhHyMCYp0PO9t6/)