### PR TITLE
Expose document generation as a github action

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -139,3 +139,6 @@ ref/*
 
 # Summary.md
 SUMMARY.md
+
+# used while building
+repos/

--- a/README.md
+++ b/README.md
@@ -19,25 +19,25 @@ based on the
 ### Steps
 
 1. Run `pip install --upgrade git+git://github.com/wandb/client.git@<commit_id>`
-to install the version of`wandb` you wish to document.
+   to install the version of`wandb` you wish to document.
 2. Run `python generate.py --commit_id <commit_id>` to create the documentation.
-Make sure to use a full hash or tag -- it's used to create URLs.
+   Make sure to use a full hash or tag -- it's used to create URLs.
 3. Move the generated documentation into a local copy of
-[the repository for the GitBook](https://www.github.com/).
+   [the repository for the GitBook](https://www.github.com/).
 
 ### Outputs
 
 1. A folder named `ref`.
-The files in the `ref` folder are the generated markdown.
-Use the `--output_dir` option to change where this folder is saved;
-by default it is in the working directory.
-If the `output_dir` already contains a folder named `ref`,
-any contents inside the `cli` or `python` directory will be over-written.
+   The files in the `ref` folder are the generated markdown.
+   Use the `--output_dir` option to change where this folder is saved;
+   by default it is in the working directory.
+   If the `output_dir` already contains a folder named `ref`,
+   any contents inside the `cli` or `python` directory will be over-written.
 2. A `SUMMARY.md` file for creating a
-[GitBook sidebar](https://docs.gitbook.com/integrations/github/content-configuration#summary)
-that indexes the automatically-generated docs.
-This is based on a provided `--template_file`
-\(by default, `_SUMMARY.md` from this repo\).
+   [GitBook sidebar](https://docs.gitbook.com/integrations/github/content-configuration#summary)
+   that indexes the automatically-generated docs.
+   This is based on a provided `--template_file`
+   \(by default, `_SUMMARY.md` from this repo\).
 
 ### Example Usage
 
@@ -100,8 +100,35 @@ module-doc-from=data_types
 then you'll need to add a new section to the reference docs (though it'd be easier just export them at the top level and add them to an existing section!).
 
 You'll need to
+
 1. Add a new subconfig, a la `WANDB_DATATYPES`
 2. Populate that with all the required tags (see `EXAMPLE_SUBCONFIG`)
 3. Add that subconfig to the `SUB_CONFIGS`
 4. Add handling for the new section to `generate.py`, under `get_prefix`
 5. Add handling for the new section to `library.py`, under `build`. (This last step could probably be easily automated away with some slight changes to the logic there).
+
+## Running as a GitHub Action
+
+In any wandb repo's Actions workflow, you can trigger document generation like so...
+
+```yml
+- uses: wandb/docugen@vX.Y.Z
+  with:
+    gitbook-branch: en
+    access-token: ${{ secrets.DOCUGEN_ACCESS_TOKEN }}
+```
+
+where `vX.Y.Z` is a tag on this (docugen) repo and `DOCUGEN_ACCESS_TOKEN` is a Personal Access Token with org write permissions, stored in the consuming repo. This will generate docs based on the latest releases of all contributing projects and push them to the target branch in the gitbook repo (`en` is the branch used for the main English docs).
+
+### Updating the GitHub Action
+
+After merging your changes to `docugen@main`...
+
+```bash
+git tag -a vX.Y.Z -m "docugen version X.Y.Z"
+git push origin vX.Y.Z
+```
+
+Then you'll need to update the `uses` line in the consuming repo. If we eventually have a lot of repos doing this it might be better to refer to `@main`, to save us the trouble of manually updating all of them (note that if you don't update a repo, it will trigger the old document generation logic, potentially overwriting new docs).
+
+You can test changes to the action on a branch with `uses: wandb/docugen@branch-name` from any other repo.

--- a/action.yml
+++ b/action.yml
@@ -27,9 +27,9 @@ runs:
       id: cache
       with:
         path: .cache/pip
-        key: ${{ runner.os }}-pip-${{ hashFiles(format('{0}/**/requirements.txt', github.action_path)) }}
+        key: ${{ runner.os }}-pip-${{ hashFiles(format('{0}/requirements.txt', github.action_path)) }}
         restore-keys: |
-          ${{ runner.os }}-pip-${{ hashFiles(format('{0}/**/requirements.txt', github.action_path)) }}
+          ${{ runner.os }}-pip-${{ hashFiles(format('{0}/requirements.txt', github.action_path)) }}
           ${{ runner.os }}-pip-
     - name: setup python environment, including wandb client
       shell: bash

--- a/action.yml
+++ b/action.yml
@@ -35,7 +35,7 @@ runs:
       env:
         VERSION: latest
         DOCUGEN_CONFIG_PATH: ${{ github.action_path }}/config.ini
-      run: cat $DOCUGEN_CONFIG_PATH && python ${{ github.action_path }}/generate.py --template_file ./repos/gitbook/SUMMARY.md --commit_id $VERSION --output_dir ./repos/gitbook
+      run: python ${{ github.action_path }}/generate.py --template_file ./repos/gitbook/SUMMARY.md --commit_id $VERSION --output_dir ./repos/gitbook
     # for debugging/tracking, display the generated table of contents
     - name: display ToC
       shell: bash

--- a/action.yml
+++ b/action.yml
@@ -27,7 +27,7 @@ runs:
       id: cache
       with:
         path: .cache/pip
-        key: ${{ runner.os }}-pip-${{ hashFiles(github.action_path + '**/requirements.txt') }}
+        key: ${{ runner.os }}-pip-${{ hashFiles(format('{0}/**/requirements.txt', github.action_path)) }}
         restore-keys: |
           ${{ runner.os }}-pip-${{ hashFiles(github.action_path + '**/requirements.txt') }}
     - name: setup python environment, including wandb client

--- a/action.yml
+++ b/action.yml
@@ -11,13 +11,6 @@ inputs:
 runs:
   using: "composite"
   steps:
-    # # setup: checkout docugen tool and docs from github
-    # - name: checkout docugen repo
-    #   uses: actions/checkout@v2
-    #   with:
-    #     repository: wandb/docugen
-    #     path: documentation/docugen
-    #     token: ${{ inputs.access-token }}
     - name: checkout gitbook repo
       uses: actions/checkout@v2
       with:
@@ -34,7 +27,7 @@ runs:
       shell: bash
       env:
         VERSION: latest
-      run: python -m pip install -r ./docugen/requirements.txt git+https://github.com/wandb/client.git@$VERSION
+      run: python -m pip install -r ./requirements.txt git+https://github.com/wandb/client.git@$VERSION
 
     # generate the docs from the latest client library and overwrite gitbook contents
     - name: generate documentation

--- a/action.yml
+++ b/action.yml
@@ -17,6 +17,7 @@ runs:
         repository: wandb/gitbook
         path: repos/gitbook
         ref: ${{ inputs.gitbook-branch }}
+        token: ${{ inputs.access-token }}
     # setup: bring in python plus the requirements for generating docs and the new release
     - name: setup python
       uses: actions/setup-python@v2

--- a/action.yml
+++ b/action.yml
@@ -56,5 +56,5 @@ runs:
       shell: bash
       working-directory: ./repos/gitbook
       run: |
-        git remote set-url origin git@github.com:wandb/gitbook.git
+        git remote set-url origin https://${{ inputs.access-token }}@github.com:wandb/gitbook.git
         git push

--- a/action.yml
+++ b/action.yml
@@ -5,11 +5,8 @@ inputs:
     description: "Which branch of wandb/gitbook to update"
     required: true
     default: "en"
-  gitbook-ssh-passphrase:
-    description: "SSH passphrase to use when pushing to gitbook repo"
-    required: true
-  gitbook-ssh-private-key:
-    description: "SSH private key to use when pushing to gitbook repo."
+  access-token:
+    description: "Personal access token to use when checking out repos"
     required: true
 runs:
   using: "composite"
@@ -20,14 +17,14 @@ runs:
       with:
         repository: wandb/docugen
         path: documentation/docugen
-        persist-credentials: false
+        token: ${{ inputs.access-token }}
     - name: checkout gitbook repo
       uses: actions/checkout@v2
       with:
         repository: wandb/gitbook
         path: documentation/gitbook
         ref: ${{ inputs.gitbook-branch }}
-        persist-credentials: false
+        token: ${{ inputs.access-token }}
     # setup: bring in python plus the requirements for generating docs and the new release
     - name: setup python
       uses: actions/setup-python@v2
@@ -50,26 +47,6 @@ runs:
     - name: display ToC
       shell: bash
       run: cat ./documentation/gitbook/SUMMARY.md
-
-    # authenticate machine user via SSH
-    - name: SSH authentication
-      shell: bash
-      env:
-        SSH_PASSPHRASE: ${{ inputs.gitbook-ssh-passphrase }}
-        SSH_PRIVATE_KEY: ${{ inputs.gitbook-ssh-private-key }}
-      run: |
-        # create an agent pointing at the shared socket > hiding output
-        ssh-agent -a $SSH_AUTH_SOCK > /dev/null
-        # put the passphrase > into a file && make it executable
-        echo 'echo $SSH_PASSPHRASE' > ~/.ssh_askpass && chmod +x ~/.ssh_askpass
-        # pass the private key | sans carriage returns | to ssh-add, along with the password returned by the file > hiding output
-        echo "$SSH_PRIVATE_KEY" | tr -d '\r' | DISPLAY=NONE SSH_ASKPASS=~/.ssh_askpass ssh-add - > /dev/null
-        rm ~/.ssh_askpass
-
-    # debug step: print out the added identity
-    - name: print ssh-add identities
-      shell: bash
-      run: ssh-add -l
 
     # stage: commit the changes
     - name: commit changes

--- a/action.yml
+++ b/action.yml
@@ -1,0 +1,84 @@
+name: "Update docs"
+description: "Generate markdown documentation, commit it to a branch of the gitbook repo, and push it"
+inputs:
+  gitbook-branch:
+    description: "Which branch of wandb/gitbook to update"
+    required: true
+    default: "en"
+runs:
+  using: "composite"
+  steps:
+    # setup: checkout docugen tool and docs from github
+    - name: checkout docugen repo
+      uses: actions/checkout@v2
+      with:
+        repository: wandb/docugen
+        path: documentation/docugen
+        persist-credentials: false
+    - name: checkout gitbook repo
+      uses: actions/checkout@v2
+      with:
+        repository: wandb/gitbook
+        path: documentation/gitbook
+        ref: ${{ input.gitbook-branch }}
+        persist-credentials: false
+    # setup: bring in python plus the requirements for generating docs and the new release
+    - name: setup python
+      uses: actions/setup-python@v2
+      with:
+        python-version: "3.9"
+    - name: setup python environment, including wandb client
+      shell: bash
+      env:
+        VERSION: latest
+      run: python -m pip install -r ./documentation/docugen/requirements.txt git+https://github.com/wandb/client.git@$VERSION
+
+    # generate the docs from the latest client library and overwrite gitbook contents
+    - name: generate documentation
+      shell: bash
+      working-directory: ./documentation/docugen
+      env:
+        VERSION: latest
+      run: python generate.py --template_file ../gitbook/SUMMARY.md --commit_id $VERSION --output_dir ../gitbook
+    # for debugging/tracking, display the generated table of contents
+    - name: display ToC
+      shell: bash
+      run: cat ./documentation/gitbook/SUMMARY.md
+
+    # authenticate machine user via SSH
+    - name: SSH authentication from secrets
+      shell: bash
+      env:
+        SSH_PASSPHRASE: ${{ secrets.WANDB_GITBOOK_SSH_PASSPHRASE }}
+        SSH_PRIVATE_KEY: ${{ secrets.WANDB_GITBOOK_SSH_PRIVATE_KEY }}
+      run: |
+        # create an agent pointing at the shared socket > hiding output
+        ssh-agent -a $SSH_AUTH_SOCK > /dev/null
+        # put the passphrase > into a file && make it executable
+        echo 'echo $SSH_PASSPHRASE' > ~/.ssh_askpass && chmod +x ~/.ssh_askpass
+        # pass the private key | sans carriage returns | to ssh-add, along with the password returned by the file > hiding output
+        echo "$SSH_PRIVATE_KEY" | tr -d '\r' | DISPLAY=NONE SSH_ASKPASS=~/.ssh_askpass ssh-add - > /dev/null
+        rm ~/.ssh_askpass
+
+    # debug step: print out the added identity
+    - name: print ssh-add identities
+      shell: bash
+      run: ssh-add -l
+
+    # stage: commit the changes
+    - name: commit changes
+      shell: bash
+      working-directory: ./documentation/gitbook
+      run: |
+        git config --local user.email "41898282+github-actions[bot]@users.noreply.github.com"
+        git config --local user.name "github-actions[bot]"
+        git add -A .
+        git commit -m "update reference docs to latest CLI"
+
+    # deploy: push to the gitbook repository
+    - name: push
+      shell: bash
+      working-directory: ./documentation/gitbook
+      run: |
+        git remote set-url origin git@github.com:wandb/gitbook.git
+        git push

--- a/action.yml
+++ b/action.yml
@@ -30,6 +30,7 @@ runs:
         key: ${{ runner.os }}-pip-${{ hashFiles(format('{0}/**/requirements.txt', github.action_path)) }}
         restore-keys: |
           ${{ runner.os }}-pip-${{ hashFiles(format('{0}/**/requirements.txt', github.action_path)) }}
+          ${{ runner.os }}-pip-
     - name: setup python environment, including wandb client
       shell: bash
       env:

--- a/action.yml
+++ b/action.yml
@@ -22,6 +22,10 @@ runs:
       uses: actions/setup-python@v2
       with:
         python-version: "3.9"
+        cache: "pip"
+        cache-dependency-path: |
+          ${{ github.action_path }}/requirements.txt
+          ${{ github.action_path }}/docugen/requirements.txt
     - name: setup python environment, including wandb client
       shell: bash
       env:

--- a/action.yml
+++ b/action.yml
@@ -23,14 +23,6 @@ runs:
       uses: actions/setup-python@v2
       with:
         python-version: "3.9"
-    - uses: actions/cache@v1
-      id: cache
-      with:
-        path: .cache/pip
-        key: ${{ runner.os }}-pip-${{ hashFiles(format('{0}/requirements.txt', github.action_path)) }}
-        restore-keys: |
-          ${{ runner.os }}-pip-${{ hashFiles(format('{0}/requirements.txt', github.action_path)) }}
-          ${{ runner.os }}-pip-
     - name: setup python environment, including wandb client
       shell: bash
       env:

--- a/action.yml
+++ b/action.yml
@@ -27,7 +27,7 @@ runs:
       shell: bash
       env:
         VERSION: latest
-      run: python -m pip install -r ./requirements.txt git+https://github.com/wandb/client.git@$VERSION
+      run: pwd && ls . && python -m pip install -r ./requirements.txt git+https://github.com/wandb/client.git@$VERSION
 
     # generate the docs from the latest client library and overwrite gitbook contents
     - name: generate documentation

--- a/action.yml
+++ b/action.yml
@@ -56,5 +56,5 @@ runs:
       shell: bash
       working-directory: ./repos/gitbook
       run: |
-        git remote set-url origin https://${{ inputs.access-token }}@github.com:wandb/gitbook.git
+        git remote set-url origin https://${{ inputs.access-token }}@github.com/wandb/gitbook.git
         git push

--- a/action.yml
+++ b/action.yml
@@ -29,7 +29,7 @@ runs:
         path: .cache/pip
         key: ${{ runner.os }}-pip-${{ hashFiles(format('{0}/**/requirements.txt', github.action_path)) }}
         restore-keys: |
-          ${{ runner.os }}-pip-${{ hashFiles(github.action_path + '**/requirements.txt') }}
+          ${{ runner.os }}-pip-${{ hashFiles(format('{0}/**/requirements.txt', github.action_path)) }}
     - name: setup python environment, including wandb client
       shell: bash
       env:

--- a/action.yml
+++ b/action.yml
@@ -5,6 +5,12 @@ inputs:
     description: "Which branch of wandb/gitbook to update"
     required: true
     default: "en"
+  gitbook-ssh-passphrase:
+    description: "SSH passphrase to use when pushing to gitbook repo"
+    required: true
+  gitbook-ssh-private-key:
+    description: "SSH private key to use when pushing to gitbook repo."
+    required: true
 runs:
   using: "composite"
   steps:
@@ -20,7 +26,7 @@ runs:
       with:
         repository: wandb/gitbook
         path: documentation/gitbook
-        ref: ${{ input.gitbook-branch }}
+        ref: ${{ inputs.gitbook-branch }}
         persist-credentials: false
     # setup: bring in python plus the requirements for generating docs and the new release
     - name: setup python
@@ -46,11 +52,11 @@ runs:
       run: cat ./documentation/gitbook/SUMMARY.md
 
     # authenticate machine user via SSH
-    - name: SSH authentication from secrets
+    - name: SSH authentication
       shell: bash
       env:
-        SSH_PASSPHRASE: ${{ secrets.WANDB_GITBOOK_SSH_PASSPHRASE }}
-        SSH_PRIVATE_KEY: ${{ secrets.WANDB_GITBOOK_SSH_PRIVATE_KEY }}
+        SSH_PASSPHRASE: ${{ inputs.gitbook-ssh-passphrase }}
+        SSH_PRIVATE_KEY: ${{ inputs.gitbook-ssh-private-key }}
       run: |
         # create an agent pointing at the shared socket > hiding output
         ssh-agent -a $SSH_AUTH_SOCK > /dev/null

--- a/action.yml
+++ b/action.yml
@@ -35,7 +35,7 @@ runs:
       env:
         VERSION: latest
         DOCUGEN_CONFIG_PATH: ${{ github.action_path }}/config.ini
-      run: python ${{ github.action_path }}/generate.py --template_file ./repos/gitbook/SUMMARY.md --commit_id $VERSION --output_dir ./repos/gitbook
+      run: cat $DOCUGEN_CONFIG_PATH && python ${{ github.action_path }}/generate.py --template_file ./repos/gitbook/SUMMARY.md --commit_id $VERSION --output_dir ./repos/gitbook
     # for debugging/tracking, display the generated table of contents
     - name: display ToC
       shell: bash

--- a/action.yml
+++ b/action.yml
@@ -23,10 +23,13 @@ runs:
       uses: actions/setup-python@v2
       with:
         python-version: "3.9"
-        cache: "pip"
-        cache-dependency-path: |
-          ${{ github.action_path }}/requirements.txt
-          ${{ github.action_path }}/docugen/requirements.txt
+    - uses: actions/cache@v1
+      id: cache
+      with:
+        path: .cache/pip
+        key: ${{ runner.os }}-pip-${{ hashFiles(github.action_path + '**/requirements.txt') }}
+        restore-keys: |
+          ${{ runner.os }}-pip-${{ hashFiles(github.action_path + '**/requirements.txt') }}
     - name: setup python environment, including wandb client
       shell: bash
       env:

--- a/action.yml
+++ b/action.yml
@@ -17,7 +17,6 @@ runs:
         repository: wandb/gitbook
         path: repos/gitbook
         ref: ${{ inputs.gitbook-branch }}
-        token: ${{ inputs.access-token }}
     # setup: bring in python plus the requirements for generating docs and the new release
     - name: setup python
       uses: actions/setup-python@v2

--- a/action.yml
+++ b/action.yml
@@ -11,18 +11,18 @@ inputs:
 runs:
   using: "composite"
   steps:
-    # setup: checkout docugen tool and docs from github
-    - name: checkout docugen repo
-      uses: actions/checkout@v2
-      with:
-        repository: wandb/docugen
-        path: documentation/docugen
-        token: ${{ inputs.access-token }}
+    # # setup: checkout docugen tool and docs from github
+    # - name: checkout docugen repo
+    #   uses: actions/checkout@v2
+    #   with:
+    #     repository: wandb/docugen
+    #     path: documentation/docugen
+    #     token: ${{ inputs.access-token }}
     - name: checkout gitbook repo
       uses: actions/checkout@v2
       with:
         repository: wandb/gitbook
-        path: documentation/gitbook
+        path: repos/gitbook
         ref: ${{ inputs.gitbook-branch }}
         token: ${{ inputs.access-token }}
     # setup: bring in python plus the requirements for generating docs and the new release
@@ -34,24 +34,23 @@ runs:
       shell: bash
       env:
         VERSION: latest
-      run: python -m pip install -r ./documentation/docugen/requirements.txt git+https://github.com/wandb/client.git@$VERSION
+      run: python -m pip install -r ./docugen/requirements.txt git+https://github.com/wandb/client.git@$VERSION
 
     # generate the docs from the latest client library and overwrite gitbook contents
     - name: generate documentation
       shell: bash
-      working-directory: ./documentation/docugen
       env:
         VERSION: latest
-      run: python generate.py --template_file ../gitbook/SUMMARY.md --commit_id $VERSION --output_dir ../gitbook
+      run: python generate.py --template_file ./repos/gitbook/SUMMARY.md --commit_id $VERSION --output_dir ../gitbook
     # for debugging/tracking, display the generated table of contents
     - name: display ToC
       shell: bash
-      run: cat ./documentation/gitbook/SUMMARY.md
+      run: cat ./repos/gitbook/SUMMARY.md
 
     # stage: commit the changes
     - name: commit changes
       shell: bash
-      working-directory: ./documentation/gitbook
+      working-directory: ./repos/gitbook
       run: |
         git config --local user.email "41898282+github-actions[bot]@users.noreply.github.com"
         git config --local user.name "github-actions[bot]"
@@ -61,7 +60,7 @@ runs:
     # deploy: push to the gitbook repository
     - name: push
       shell: bash
-      working-directory: ./documentation/gitbook
+      working-directory: ./repos/gitbook
       run: |
         git remote set-url origin git@github.com:wandb/gitbook.git
         git push

--- a/action.yml
+++ b/action.yml
@@ -27,14 +27,14 @@ runs:
       shell: bash
       env:
         VERSION: latest
-      run: pwd && ls . && python -m pip install -r ./requirements.txt git+https://github.com/wandb/client.git@$VERSION
+      run: python -m pip install -r ${{ github.action_path }}/requirements.txt git+https://github.com/wandb/client.git@$VERSION
 
     # generate the docs from the latest client library and overwrite gitbook contents
     - name: generate documentation
       shell: bash
       env:
         VERSION: latest
-      run: python generate.py --template_file ./repos/gitbook/SUMMARY.md --commit_id $VERSION --output_dir ../gitbook
+      run: python ${{ github.action_path }}/generate.py --template_file ./repos/gitbook/SUMMARY.md --commit_id $VERSION --output_dir ./repos/gitbook
     # for debugging/tracking, display the generated table of contents
     - name: display ToC
       shell: bash

--- a/action.yml
+++ b/action.yml
@@ -34,6 +34,7 @@ runs:
       shell: bash
       env:
         VERSION: latest
+        DOCUGEN_CONFIG_PATH: ${{ github.action_path }}/config.ini
       run: python ${{ github.action_path }}/generate.py --template_file ./repos/gitbook/SUMMARY.md --commit_id $VERSION --output_dir ./repos/gitbook
     # for debugging/tracking, display the generated table of contents
     - name: display ToC

--- a/generate.py
+++ b/generate.py
@@ -318,24 +318,23 @@ def check_commit_id(commit_id):
     Args:
         commit_id: The commit id provided
     """
-    pass
-    # if commit_id == "latest":
-    #     # using latest version instead of a commit id -- this should work as long as
-    #     # we aren't hosting legacy doc versions -- if we do, we'll need to go back
-    #     # to passing an actual id
-    #     pass
-    # elif "." in commit_id:
-    #     # commit_id is a version
-    #     wandb_version = f"v{wandb.__version__}"
-    #     assert (
-    #         wandb_version == commit_id
-    #     ), f"git version {commit_id} does not match wandb version {wandb_version}"
-    # else:
-    #     # commit_id is a git hash
-    #     commit_id_len = len(commit_id)
-    #     assert (
-    #         commit_id_len == 40
-    #     ), f"git hash must have all 40 characters, was {commit_id}"
+    if commit_id == "latest":
+        # using latest version instead of a commit id -- this should work as long as
+        # we aren't hosting legacy doc versions -- if we do, we'll need to go back
+        # to passing an actual id
+        pass
+    elif "." in commit_id:
+        # commit_id is a version
+        wandb_version = f"v{wandb.__version__}"
+        assert (
+            wandb_version == commit_id
+        ), f"git version {commit_id} does not match wandb version {wandb_version}"
+    else:
+        # commit_id is a git hash
+        commit_id_len = len(commit_id)
+        assert (
+            commit_id_len == 40
+        ), f"git hash must have all 40 characters, was {commit_id}"
 
 
 if __name__ == "__main__":

--- a/generate.py
+++ b/generate.py
@@ -318,7 +318,12 @@ def check_commit_id(commit_id):
     Args:
         commit_id: The commit id provided
     """
-    if "." in commit_id:
+    if commit_id == "latest":
+        # using latest version instead of a commit id -- this should work as long as
+        # we aren't hosting legacy doc versions -- if we do, we'll need to go back
+        # to passing an actual id
+        pass
+    elif "." in commit_id:
         # commit_id is a version
         wandb_version = f"v{wandb.__version__}"
         assert (

--- a/generate.py
+++ b/generate.py
@@ -21,7 +21,8 @@ import util
 
 
 config = configparser.ConfigParser()
-config.read("config.ini")
+config_path = os.environ.get("DOCUGEN_CONFIG_PATH") or "./config.ini"
+config.read(config_path)
 
 DIRNAME = config["GLOBAL"]["DIRNAME"]
 DIRNAMES_TO_TITLES = config["DIRNAMES_TO_TITLES"]

--- a/generate.py
+++ b/generate.py
@@ -318,23 +318,24 @@ def check_commit_id(commit_id):
     Args:
         commit_id: The commit id provided
     """
-    if commit_id == "latest":
-        # using latest version instead of a commit id -- this should work as long as
-        # we aren't hosting legacy doc versions -- if we do, we'll need to go back
-        # to passing an actual id
-        pass
-    elif "." in commit_id:
-        # commit_id is a version
-        wandb_version = f"v{wandb.__version__}"
-        assert (
-            wandb_version == commit_id
-        ), f"git version {commit_id} does not match wandb version {wandb_version}"
-    else:
-        # commit_id is a git hash
-        commit_id_len = len(commit_id)
-        assert (
-            commit_id_len == 40
-        ), f"git hash must have all 40 characters, was {commit_id}"
+    pass
+    # if commit_id == "latest":
+    #     # using latest version instead of a commit id -- this should work as long as
+    #     # we aren't hosting legacy doc versions -- if we do, we'll need to go back
+    #     # to passing an actual id
+    #     pass
+    # elif "." in commit_id:
+    #     # commit_id is a version
+    #     wandb_version = f"v{wandb.__version__}"
+    #     assert (
+    #         wandb_version == commit_id
+    #     ), f"git version {commit_id} does not match wandb version {wandb_version}"
+    # else:
+    #     # commit_id is a git hash
+    #     commit_id_len = len(commit_id)
+    #     assert (
+    #         commit_id_len == 40
+    #     ), f"git hash must have all 40 characters, was {commit_id}"
 
 
 if __name__ == "__main__":

--- a/library.py
+++ b/library.py
@@ -12,6 +12,7 @@ import util
 
 config = configparser.ConfigParser()
 config_path = os.environ.get("DOCUGEN_CONFIG_PATH") or "./config.ini"
+print("READING CONFIG FROM: ", config_path)
 config.read(config_path)
 
 DIRNAME = config["GLOBAL"]["DIRNAME"]

--- a/library.py
+++ b/library.py
@@ -14,8 +14,6 @@ config = configparser.ConfigParser()
 config_path = os.environ.get("DOCUGEN_CONFIG_PATH") or "./config.ini"
 config.read(config_path)
 
-print(config.sections())
-
 DIRNAME = config["GLOBAL"]["DIRNAME"]
 LIBRARY_DIRNAME = config["WANDB_CORE"]["dirname"]
 

--- a/library.py
+++ b/library.py
@@ -12,7 +12,9 @@ import util
 
 config = configparser.ConfigParser()
 config_path = os.environ.get("DOCUGEN_CONFIG_PATH") or "./config.ini"
-print('loading', config.read(config_path))
+config.read(config_path)
+
+print(config.sections())
 
 DIRNAME = config["GLOBAL"]["DIRNAME"]
 LIBRARY_DIRNAME = config["WANDB_CORE"]["dirname"]

--- a/library.py
+++ b/library.py
@@ -12,8 +12,8 @@ import util
 
 config = configparser.ConfigParser()
 config_path = os.environ.get("DOCUGEN_CONFIG_PATH") or "./config.ini"
-print("READING CONFIG FROM: ", config_path)
-config.read(config_path)
+config_file = open(config_path)
+config.read_file(config_file)
 
 DIRNAME = config["GLOBAL"]["DIRNAME"]
 LIBRARY_DIRNAME = config["WANDB_CORE"]["dirname"]

--- a/library.py
+++ b/library.py
@@ -12,8 +12,11 @@ import util
 
 config = configparser.ConfigParser()
 config_path = os.environ.get("DOCUGEN_CONFIG_PATH") or "./config.ini"
-config_file = open(config_path)
-config.read_file(config_file)
+with open(config_path) as config_file:
+    config_string = config_file.read()
+
+    print('config file contains: \n', config_string)
+    config.read_string(config_string)
 
 DIRNAME = config["GLOBAL"]["DIRNAME"]
 LIBRARY_DIRNAME = config["WANDB_CORE"]["dirname"]

--- a/library.py
+++ b/library.py
@@ -11,7 +11,8 @@ from docugen import generate
 import util
 
 config = configparser.ConfigParser()
-config.read("config.ini")
+config_path = os.environ.get("DOCUGEN_CONFIG_PATH") or "./config.ini"
+config.read(config_path)
 
 DIRNAME = config["GLOBAL"]["DIRNAME"]
 LIBRARY_DIRNAME = config["WANDB_CORE"]["dirname"]

--- a/library.py
+++ b/library.py
@@ -12,11 +12,7 @@ import util
 
 config = configparser.ConfigParser()
 config_path = os.environ.get("DOCUGEN_CONFIG_PATH") or "./config.ini"
-with open(config_path) as config_file:
-    config_string = config_file.read()
-
-    print('config file contains: \n', config_string)
-    config.read_string(config_string)
+print('loading', config.read(config_path))
 
 DIRNAME = config["GLOBAL"]["DIRNAME"]
 LIBRARY_DIRNAME = config["WANDB_CORE"]["dirname"]

--- a/library.py
+++ b/library.py
@@ -16,6 +16,8 @@ config.read(config_path)
 
 DIRNAME = config["GLOBAL"]["DIRNAME"]
 LIBRARY_DIRNAME = config["WANDB_CORE"]["dirname"]
+DIRNAMES_TO_TITLES = config["DIRNAMES_TO_TITLES"]
+SKIPS = config["SKIPS"]["elements"].split(",")
 
 subconfig_names = config["SUBCONFIGS"]["names"].split(",")
 


### PR DESCRIPTION
In any wandb repo, you can now do...

```yml
      - uses: wandb/docugen@vX.Y.Z
        with:
          gitbook-branch: en
          access-token: ${{ secrets.DOCUGEN_ACCESS_TOKEN }}
```
where `vX.Y.Z` is a tag on this (docugen) repo and `DOCUGEN_ACCESS_TOKEN` is a Personal Access Token with org write permissions, stored in the consuming repo. I haven't published a tag yet -- I'm going to wait to do that until we merge this PR. I've been testing by referring to the branch (`@gh-action`) instead.

The action generates the docs based on the most current wandb release at the time you run it, which means that you have to release/tag CLI before running this action if you're running it from CLI. As docugen expands, it'll treat other documentation sources the same way, pulling in the most up-to-date released version of each, and using it to run doc generation. That way, it shouldn't matter where/when you run this action -- it'll always generate the most up-to-date documentation, regardless of where it was invoked.

`en` is the branch that the main English docs on GitBook are tracking. You can test changes to docugen by specifying a different branch and creating a new private workspace in GitBook to track that branch.