### PR TITLE
Automatically generate Weave documentation

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -62,6 +62,7 @@ runs:
     - name: generate weave documentation
       shell: bash
       run: |
+        yarn --cwd=./repos/core/lib/js/cg --frozen-lockfile
         yarn --cwd=./repos/core/lib/js/cg generate-docs
         cp -r ./repos/core/lib/js/cg/docs_gen/types/* ./repos/gitbook/ref/weave/types
 

--- a/action.yml
+++ b/action.yml
@@ -61,7 +61,7 @@ runs:
         cp -r ./repos/core/lib/js/cg/docs_gen/* ./repos/gitbook/ref/weave
 
     # generate the docs from the latest client library and overwrite gitbook contents
-    - name: generate client documentation
+    - name: generate SDK documentation
       shell: bash
       env:
         VERSION: latest

--- a/action.yml
+++ b/action.yml
@@ -36,13 +36,35 @@ runs:
         VERSION: latest
       run: python -m pip install -r ${{ github.action_path }}/requirements.txt git+https://github.com/wandb/client.git@$VERSION
 
+    - name: checkout wandb/core
+      uses: actions/checkout@v2
+      with:
+        repository: wandb/core
+        path: repos/core
+        ref: ${{ inputs.core-branch }}
+        token: ${{ inputs.access-token }}
+
+    - name: setup node
+      uses: actions/setup-node@v2
+      with:
+        node-version: "16"
+        cache: "yarn"
+        cache-dependency-path: repos/core/lib/js/cg/yarn.lock
+
     # generate the docs from the latest client library and overwrite gitbook contents
-    - name: generate documentation
+    - name: generate client documentation
       shell: bash
       env:
         VERSION: latest
         DOCUGEN_CONFIG_PATH: ${{ github.action_path }}/config.ini
       run: python ${{ github.action_path }}/generate.py --template_file ./repos/gitbook/SUMMARY.md --commit_id $VERSION --output_dir ./repos/gitbook
+
+    - name: generate weave documentation
+      shell: bash
+      run: |
+        yarn --cwd=./repos/core/lib/js/cg generate-docs
+        cp -r ./repos/core/lib/js/cg/docs_gen/types/* ./repos/gitbook/ref/weave/types
+
     # for debugging/tracking, display the generated table of contents
     - name: display ToC
       shell: bash

--- a/action.yml
+++ b/action.yml
@@ -65,6 +65,7 @@ runs:
         yarn --cwd=./repos/core/lib/js/cg --frozen-lockfile
         yarn --cwd=./repos/core/lib/js/cg generate-docs
         rm -rf ./repos/gitbook/ref/weave/**
+        mkdir -p ./repos/gitbook/ref/weave
         cp -r ./repos/core/lib/js/cg/docs_gen/* ./repos/gitbook/ref/weave
 
     # for debugging/tracking, display the generated table of contents

--- a/action.yml
+++ b/action.yml
@@ -86,6 +86,7 @@ runs:
           git add -A .
           git commit -m "update reference docs to cli@${{ inputs.client-branch }}, core@${{ inputs.core-branch }}"
           git remote set-url origin https://${{ inputs.access-token }}@github.com/wandb/gitbook.git ; \
+          git pull ; \
           git push ; \
         else
           echo "Documentation has not changed; skipping commit/push" ;

--- a/action.yml
+++ b/action.yml
@@ -64,7 +64,8 @@ runs:
       run: |
         yarn --cwd=./repos/core/lib/js/cg --frozen-lockfile
         yarn --cwd=./repos/core/lib/js/cg generate-docs
-        cp -r ./repos/core/lib/js/cg/docs_gen/types/* ./repos/gitbook/ref/weave/types
+        rm -rf ./repos/gitbook/ref/weave/**
+        cp -r ./repos/core/lib/js/cg/docs_gen/* ./repos/gitbook/ref/weave
 
     # for debugging/tracking, display the generated table of contents
     - name: display ToC

--- a/action.yml
+++ b/action.yml
@@ -51,14 +51,6 @@ runs:
         cache: "yarn"
         cache-dependency-path: repos/core/lib/js/cg/yarn.lock
 
-    # generate the docs from the latest client library and overwrite gitbook contents
-    - name: generate client documentation
-      shell: bash
-      env:
-        VERSION: latest
-        DOCUGEN_CONFIG_PATH: ${{ github.action_path }}/config.ini
-      run: python ${{ github.action_path }}/generate.py --template_file ./repos/gitbook/SUMMARY.md --commit_id $VERSION --output_dir ./repos/gitbook
-
     - name: generate weave documentation
       shell: bash
       run: |
@@ -67,6 +59,14 @@ runs:
         rm -rf ./repos/gitbook/ref/weave/**
         mkdir -p ./repos/gitbook/ref/weave
         cp -r ./repos/core/lib/js/cg/docs_gen/* ./repos/gitbook/ref/weave
+
+    # generate the docs from the latest client library and overwrite gitbook contents
+    - name: generate client documentation
+      shell: bash
+      env:
+        VERSION: latest
+        DOCUGEN_CONFIG_PATH: ${{ github.action_path }}/config.ini
+      run: python ${{ github.action_path }}/generate.py --template_file ./repos/gitbook/SUMMARY.md --commit_id $VERSION --output_dir ./repos/gitbook
 
     # for debugging/tracking, display the generated table of contents
     - name: display ToC

--- a/config.ini
+++ b/config.ini
@@ -18,7 +18,12 @@ weave=Weave
 
 [SKIPS]
 # subdirectories of ref/ to skip when creating table of contents/SUMMARY.md
-elements=app,java,weave
+elements=app,java
+
+[EXTERNAL]
+# the content of these directories is generated from outside of docugen,
+# so they should not be erased on startup, but they _do_ need to be walked.
+elements=weave
 
 ###
 #

--- a/config.ini
+++ b/config.ini
@@ -14,6 +14,7 @@ data-types=Data Types
 public-api=Import & Export API
 integrations=Integrations
 keras=Keras
+weave=Weave
 
 [SKIPS]
 # subdirectories of ref/ to skip when creating table of contents/SUMMARY.md

--- a/config.ini
+++ b/config.ini
@@ -18,7 +18,7 @@ weave=Weave
 
 [SKIPS]
 # subdirectories of ref/ to skip when creating table of contents/SUMMARY.md
-elements=app,java
+elements=app,java,weave
 
 ###
 #

--- a/generate.py
+++ b/generate.py
@@ -33,7 +33,7 @@ def main(args):
 
     ref_dir = os.path.join(output_dir, library.DIRNAME)
     for library.dirname in library.DIRNAMES_TO_TITLES.keys():
-        if library.dirname in library.SKIPS:
+        if library.dirname in library.SKIPS or library.dirname in library.EXTERNAL:
             continue
         shutil.rmtree(os.path.join(ref_dir, library.dirname), ignore_errors=True)
 

--- a/library.py
+++ b/library.py
@@ -18,6 +18,7 @@ DIRNAME = config["GLOBAL"]["DIRNAME"]
 LIBRARY_DIRNAME = config["WANDB_CORE"]["dirname"]
 DIRNAMES_TO_TITLES = config["DIRNAMES_TO_TITLES"]
 SKIPS = config["SKIPS"]["elements"].split(",")
+EXTERNAL = config["EXTERNAL"]["elements"].split(",")
 
 subconfig_names = config["SUBCONFIGS"]["names"].split(",")
 


### PR DESCRIPTION
Goes with changes in the private wandb/core repo to automatically generate documentation based on docstrings for Weave ops.

This new version will:

* check out core
* install node and the dependencies for core's `cg` library
* run a node-based documentation generator script in cg, which outputs a number of markdown files
* copy those markdown files into the docugen repo
* merge the core-generated markdown into the other markdown files created by docugen