### PR TITLE
Created GitHub action for docodile

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -1,8 +1,8 @@
 name: "Update docs"
-description: "Generate markdown documentation, commit it to a branch of the gitbook repo, and push it"
+description: "Generate markdown documentation, commit it to a branch of the docodile repo, and create pull request"
 inputs:
-  gitbook-branch:
-    description: "Which branch of wandb/gitbook to update (use 'en' to update the main English docs)"
+  docodile-branch:
+    description: "Which branch of wandb/docodile to update"
     required: true
   core-branch:
     description: "Which branch of wandb/core to use as the source for the docs"
@@ -18,12 +18,12 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - name: checkout gitbook repo
+    - name: checkout docodile repo
       uses: actions/checkout@v2
       with:
-        repository: wandb/gitbook
-        path: repos/gitbook
-        ref: ${{ inputs.gitbook-branch }}
+        repository: wandb/docodile
+        path: repos/docodile
+        ref: ${{ inputs.docodile-branch }}
         token: ${{ inputs.access-token }}
     # setup: bring in python plus the requirements for generating docs and the new release
     - name: setup python
@@ -56,27 +56,21 @@ runs:
       run: |
         yarn --cwd=./repos/core/lib/js/cg --frozen-lockfile
         yarn --cwd=./repos/core/lib/js/cg generate-docs
-        rm -rf ./repos/gitbook/ref/weave/**
-        mkdir -p ./repos/gitbook/ref/weave
-        cp -r ./repos/core/lib/js/cg/docs_gen/* ./repos/gitbook/ref/weave
+        rm -rf ./repos/docodile/docs/ref/weave/**
+        mkdir -p ./repos/docodile/docs/ref/weave
+        cp -r ./repos/core/lib/js/cg/docs_gen/* ./repos/docodile/docs/ref/weave
 
-    # generate the docs from the latest client library and overwrite gitbook contents
+    # generate the docs from the latest client library and overwrite docodile contents
     - name: generate SDK documentation
       shell: bash
       env:
         VERSION: latest
-        DOCUGEN_CONFIG_PATH: ${{ github.action_path }}/config.ini
-      run: python ${{ github.action_path }}/generate.py --template_file ./repos/gitbook/SUMMARY.md --commit_id $VERSION --output_dir ./repos/gitbook
-
-    # for debugging/tracking, display the generated table of contents
-    - name: display ToC
-      shell: bash
-      run: cat ./repos/gitbook/SUMMARY.md
+      run: python ${{ github.action_path }}/generate.py  --commit_id $VERSION --output_dir ./repos/docodile/docs/
 
     # stage: commit the changes
     - name: commit changes
       shell: bash
-      working-directory: ./repos/gitbook
+      working-directory: ./repos/docodile
       run: |
         # hardcoded to the user ID representing the github actions bot, see:
         # https://github.community/t/github-actions-bot-email-address/17204/6
@@ -84,11 +78,12 @@ runs:
         git config --local user.email "41898282+github-actions[bot]@users.noreply.github.com"
         git config --local user.name "github-actions[bot]"x
         if [[ `git status --porcelain` ]]; then
+          git pull 
+          git checkout -b 'release_$GITHUB_SHA'
           git add -A .
-          git commit -m "update reference docs to cli@${{ inputs.client-branch }}, core@${{ inputs.core-branch }}"
-          git remote set-url origin https://${{ inputs.access-token }}@github.com/wandb/gitbook.git ; \
-          git pull ; \
-          git push ; \
+          git commit -m "Update reference docs to cli@${{ inputs.client-branch }}, core@${{ inputs.core-branch }} using https://github.com/$GITHUB_REPOSITORY/commit/$GITHUB_SHA"
+          git remote set-url origin https://${{ inputs.access-token }}@github.com/wandb/docodile.git ; \
+          git push ; 
         else
-          echo "Documentation has not changed; skipping commit/push" ;
+          echo "Documentation has not changed; skipping commit/pull request" ;
         fi

--- a/action.yml
+++ b/action.yml
@@ -79,12 +79,11 @@ runs:
         git config --local user.email "41898282+github-actions[bot]@users.noreply.github.com"
         git config --local user.name "github-actions[bot]"x
         if [[ `git status --porcelain` ]]; then
-          git pull 
-          git checkout -b 'release_$GITHUB_SHA'
           git add -A .
-          git commit -m "Update reference docs to cli@${{ inputs.client-branch }}, core@${{ inputs.core-branch }} using https://github.com/$GITHUB_REPOSITORY/commit/$GITHUB_SHA"
+          git commit -m "update reference docs to cli@${{ inputs.client-branch }}, core@${{ inputs.core-branch }}"
           git remote set-url origin https://${{ inputs.access-token }}@github.com/wandb/docodile.git ; \
-          git push ; 
+          git pull ; \
+          git push ; \
         else
-          echo "Documentation has not changed; skipping commit/pull request" ;
+          echo "Documentation has not changed; skipping commit/push" ;
         fi

--- a/action.yml
+++ b/action.yml
@@ -65,6 +65,7 @@ runs:
       shell: bash
       env:
         VERSION: latest
+        DOCUGEN_CONFIG_PATH: ${{ github.action_path }}/config.ini
       run: python ${{ github.action_path }}/generate.py  --commit_id $VERSION --output_dir ./repos/docodile/docs/
 
     # stage: commit the changes

--- a/action.yml
+++ b/action.yml
@@ -1,5 +1,5 @@
 name: "Update docs"
-description: "Generate markdown documentation, commit it to a branch of the docodile repo, and create pull request"
+description: "Generate markdown documentation, commit it to a branch of the docodile repo, and push it"
 inputs:
   docodile-branch:
     description: "Which branch of wandb/docodile to update"
@@ -80,7 +80,7 @@ runs:
         git config --local user.name "github-actions[bot]"x
         if [[ `git status --porcelain` ]]; then
           git add -A .
-          git commit -m "update reference docs to cli@${{ inputs.client-branch }}, core@${{ inputs.core-branch }}"
+          git commit -m "Update reference docs to cli@${{ inputs.client-branch }}, core@${{ inputs.core-branch }} using https://github.com/$GITHUB_REPOSITORY/commit/$GITHUB_SHA
           git remote set-url origin https://${{ inputs.access-token }}@github.com/wandb/docodile.git ; \
           git pull ; \
           git push ; \


### PR DESCRIPTION
Create a new tag `v0.2.0-docodile-beta`, with this action.yml file. Some notes:

1. This is part of the https://github.com/wandb/docugen/releases/tag/v0.2.0-docodile-beta
2. Removed creation, use of a SUMMARY.md file, we don't need it for docusuarus.
3. The GH action we have for GitBook directly pushes to main, this time we want to create a PR that is human-reviewed before it is merged into main. Re: If not formatted correctly, the auto-gen docs can break docodile. 
