### PR TITLE
Update config after artifacts refactoring

### DIFF
--- a/config.ini
+++ b/config.ini
@@ -75,7 +75,7 @@ title=Import & Export API
 slug=wandb.apis.public.
 elements=
 add-from=apis.public
-add-elements=Api,Projects,Project,Runs,Run,Sweep,Files,File,Artifact
+add-elements=Api,Projects,Project,Runs,Run,Sweep,Files,File
 module-doc-from=apis.public
 
 [WANDB_INTEGRATIONS]


### PR DESCRIPTION
# Description

After https://github.com/wandb/wandb/pull/5454 there's only one `Artifact` class. I updated the config accordingly.

# Test plan

Generated the reference docs and made sure `ref/python/artifact.md` looks good.
```
$ pip install -r requirements.txt
$ python generate.py --commit_id 3aeab0af7d36cdfd3850e3e356cf66506db6adf9
```