### PR TITLE
Add data_types.WBTraceTree to config.ini

### DIFF
--- a/config.ini
+++ b/config.ini
@@ -65,7 +65,7 @@ title=Data Types
 slug=wandb.data\_types.
 elements=Graph,Image,Plotly,Video,Audio,Table,Html,Object3D,Molecule,Histogram
 add-from=data_types
-add-elements=ImageMask,BoundingBoxes2D
+add-elements=ImageMask,BoundingBoxes2D,WBTraceTree
 module-doc-from=data_types
 
 [WANDB_API]


### PR DESCRIPTION
Fixes WB-13943

# Description

`data_types.WBTraceTree` was added to the docs manually in https://github.com/wandb/docodile/commit/112d6c48bbe610ad7121e1cd4d32acf1333bd55d. I'm adding it to the config so it doesn't get deleted when we re-generate the docs.

Required wandb change: https://github.com/wandb/wandb/pull/5788

# Test plan

Generated the docs, made sure docs for `data_types.WBTraceTree` did not get deleted:
```
$ cd ~/docugen
$ pip install -r requirements.txt
$ python generate.py --commit_id 3aeab0af7d36cdfd3850e3e356cf66506db6adf9
$ cd ~/docodile/docs/ref/python && rm -rf * && cp -r ~/docugen/ref/python/* .
```