### PR TITLE
Add __setitem__ to dunder method whitelist

### DIFF
--- a/docugen/public_api.py
+++ b/docugen/public_api.py
@@ -273,6 +273,7 @@ ALLOWED_DUNDER_METHODS = frozenset(
         "__rsub__",
         "__rtruediv__",
         "__rxor__",
+        "__setitem__",
         "__sub__",
         "__truediv__",
         "__xor__",


### PR DESCRIPTION
Fixes WB-13943

# Description

Added `__setitem__` to dunder method whitelist.

# Test plan

Tested in https://github.com/wandb/docugen/pull/32