### PR TITLE
fix support for multiline options

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -143,6 +143,8 @@ def parse_help(command: str) -> Tuple[str, str, str]:
 
     help_page = pre_process(help_page)
 
+    full_line = ""
+    tmp = None
     for line in help_page.split("\n"):
         line = line.strip()
         if line in KEYWORDS:  # Keywords contains [Options, Commands]
@@ -152,6 +154,13 @@ def parse_help(command: str) -> Tuple[str, str, str]:
         if keyword is None:
             summary.append(line)
         else:
+            # handle multi line options
+            if keyword == "Options:" and not line.startswith("-"):
+                full_line += line
+                continue
+            elif keyword == "Options:" and line.startswith("-"):
+                tmp = line
+                line = full_line
             # PATTERN helps with option and value
             # eg. --version Shows the version
             # will be captured like
@@ -159,6 +168,9 @@ def parse_help(command: str) -> Tuple[str, str, str]:
             extract = PATTERN.findall(line)
             if extract:
                 parsed_dict[keyword].append([extract[0][0], extract[0][1]])
+            if tmp is not None:
+                full_line = tmp
+                tmp = None
 
     if len(summary) == 0:
         return "", "", parsed_dict


### PR DESCRIPTION
Before we broke multi line help in cli options into a broken table. This change adds support for multiline options.


Before:
![image](https://github.com/wandb/docugen/assets/13547142/9a876ffd-4ad8-4297-a928-66480aafcfc0)


After:
![image](https://github.com/wandb/docugen/assets/13547142/2060194c-70fc-4909-b34e-d23c965e288a)
