### PR TITLE
Add launch function support

### DIFF
--- a/config.ini
+++ b/config.ini
@@ -12,6 +12,7 @@ python=Python Library
 data-types=Data Types
 public-api=Import & Export API
 integrations=Integrations
+launch=Launch
 keras=Keras
 weave=Weave
 
@@ -45,7 +46,7 @@ module-doc-from=other.module.with.dunderdoc
 
 [SUBCONFIGS]
 # add your subconfig's name here to document a new module
-names=WANDB_CORE,WANDB_DATATYPES,WANDB_API,WANDB_INTEGRATIONS
+names=WANDB_CORE,WANDB_DATATYPES,WANDB_API,WANDB_INTEGRATIONS,WANDB_LAUNCH
 
 [WANDB_CORE]
 # main python SDK library
@@ -75,7 +76,7 @@ title=Import & Export API
 slug=wandb.apis.public.
 elements=
 add-from=apis.public
-add-elements=Api,Projects,Project,Runs,Run,Sweep,Files,File
+add-elements=Api,Projects,Project,Runs,Run,Sweep,Files,File,RunQueue,Job,QueuedRun
 module-doc-from=apis.public
 
 [WANDB_INTEGRATIONS]
@@ -87,4 +88,15 @@ slug=wandb.
 elements=keras
 add-from=
 add-elements=ValidationDataLogger
+module-doc-from=
+
+
+[WANDB_LAUNCH]
+# launch ref code
+dirname=launch
+title=Launch
+slug=wandb.sdk.launch
+elements=launch,launch_add,LaunchAgent
+add-from=
+add-elements=
 module-doc-from=

--- a/library.py
+++ b/library.py
@@ -25,7 +25,7 @@ subconfig_names = config["SUBCONFIGS"]["names"].split(",")
 
 subconfigs = util.process_subconfigs(config, subconfig_names)
 
-WANDB_CORE, WANDB_DATATYPES, WANDB_API, WANDB_INTEGRATIONS = subconfigs
+WANDB_CORE, WANDB_DATATYPES, WANDB_API, WANDB_INTEGRATIONS, WANDB_LAUNCH = subconfigs
 
 
 def format_readme_titles(readme_file_path: str, markdown_titles: dict):
@@ -70,6 +70,12 @@ def build(commit_id, code_url_prefix, output_dir):
     build_docs_from_config(WANDB_API, commit_id, code_url_prefix, modules_output_dir)
     build_docs_from_config(
         WANDB_INTEGRATIONS,
+        commit_id,
+        code_url_prefix,
+        modules_output_dir,
+    )
+    build_docs_from_config(
+        WANDB_LAUNCH,
         commit_id,
         code_url_prefix,
         modules_output_dir,


### PR DESCRIPTION
In the Public API reference adds information about the QueuedRun, Job and RunQueue classes.
Sidebar:
<img width="192" alt="image" src="https://github.com/wandb/docugen/assets/13547142/88793636-a262-43c7-89b3-5dd352862b85">

Job page:
<img width="681" alt="image" src="https://github.com/wandb/docugen/assets/13547142/60282019-f410-490f-b4dd-2d1c83bfb274">


QueuedRun Page:
<img width="686" alt="image" src="https://github.com/wandb/docugen/assets/13547142/f8077630-5fc9-40f0-86a0-1e3332b003ee">


RunQueue Page:
<img width="747" alt="image" src="https://github.com/wandb/docugen/assets/13547142/fa3c23c0-799f-4e1a-8cbe-5fec14ccfb5b">



Also, with sister wandb repo PR: https://github.com/wandb/wandb/pull/6283 makes the following changes:

Adds reference docs for launch functions and classes:
- launch
- launch_add
- LaunchAgent

To our SDK reference docs.

Sidebar:
<img width="248" alt="image" src="https://github.com/wandb/docugen/assets/13547142/abb2461f-05e2-43a8-9175-7ace53ca3816">


wandb-launch page:
<img width="672" alt="image" src="https://github.com/wandb/docugen/assets/13547142/c6df6141-6ae6-4add-9c9c-334fefc2eb15">


launch:
<img width="691" alt="image" src="https://github.com/wandb/docugen/assets/13547142/f3a97b4a-fac2-4861-a6ac-0d0a4e72b683">

launch_add:
<img width="709" alt="image" src="https://github.com/wandb/docugen/assets/13547142/99d36dd5-06bc-4bb3-b01f-c88d03871a16">


LaunchAgent:
<img width="737" alt="image" src="https://github.com/wandb/docugen/assets/13547142/672b6e9f-aefd-4e6f-877e-43583526690e">




