### PR TITLE
Removed Paginator

### DIFF
--- a/library.py
+++ b/library.py
@@ -149,7 +149,7 @@ def configure_doc_hiding():
         wandb.data_types.WBValue,
         wandb.data_types.Media,
         wandb.data_types.BatchableMedia,
-        wandb.apis.public.Paginator,
+        # wandb.apis.public.Paginator,
     ]
 
     for cls in base_classes:


### PR DESCRIPTION
Removes Paginator Class from exclude list. 

`wandb/wandb` source code was refactored in v0.16.2. This lead to [docugen GitHub action build to fail on SDK release](https://github.com/wandb/wandb/actions/runs/7467254435/job/20320376269). 

[See thread for discussion](https://weightsandbiases.slack.com/archives/C02DTSCHND8/p1704925310209539).