### PR TITLE
Remove HTML, use shortcode for button

### DIFF
--- a/docugen/pretty_docs.py
+++ b/docugen/pretty_docs.py
@@ -551,21 +551,9 @@ _TABLE_TEMPLATE = textwrap.dedent(
 #     " View source on GitHub]({url})"
 # )
 
+
 _TABLE_LINK_TEMPLATE = (
-    "<p>"
-    "<button style={{{{display: 'flex', alignItems: 'center', "
-    "backgroundColor: 'white', border: '1px solid #ddd', padding: '10px', "
-    "borderRadius: '6px', cursor: 'pointer', "
-    "boxShadow: '0 2px 3px rgba(0,0,0,0.1)', transition: 'all 0.3s'}}}}>"
-    "<a href='{url}' style={{{{fontSize: '1.2em', "
-    "display: 'flex', alignItems: 'center'}}}}>"
-    "<img "
-    "src='https://github.githubassets.com/images/modules/logos_page/GitHub-Mark.png'"
-    " height='32px' width='32px' style={{{{marginRight: '10px'}}}}/>"
-    "View source on GitHub"
-    "</a>"
-    "</button>"
-    "</p>"
+    '{{< cta-button githubLink="{url}" >}}'
 )
 
 


### PR DESCRIPTION
Part of the Docusaurus -> Hugo, Docsy migration. Replaces hardoced HTML with shortcode. 

Do not merge (yet).