### PR TITLE
Hugo updates

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -16,7 +16,7 @@ PATTERN = re.compile(r"(.*?)  +(.*)")
 #           ) - End of group
 
 KEYWORDS = ["Options:", "Commands:"]
-TEMPLATE = "# {}\n\n{}\n\n{}\n{}\n{}"
+TEMPLATE = "---\ntitle: {}\n---"
 
 # Replace auto-genearted title as a key, provide the preferred title as the value
 MARKDOWN_TITLES = {"wandb": "Command Line Interface"}

--- a/docugen/pretty_docs.py
+++ b/docugen/pretty_docs.py
@@ -71,7 +71,14 @@ def _build_function_page(page_info: parser.FunctionPageInfo) -> str:
     Returns:
       The function markdown page.
     """
-    parts = [f'# {page_info.full_name.split(".")[-1]}\n\n']
+    
+    # Add the full_name of the symbol to the page.
+    title_frontmatter = f'title: {page_info.full_name.split(".")[-1]}'
+
+    parts  = []
+    parts.append(title_frontmatter) 
+
+    parts.append("\n\n")
 
     parts.append(_top_source_link(page_info.defined_in))
     parts.append("\n\n")
@@ -216,9 +223,13 @@ def _build_class_page(page_info: parser.ClassPageInfo) -> str:
     Returns:
       The class markdown page.
     """
-
     # Add the full_name of the symbol to the page.
-    parts = [f'# {page_info.full_name.split(".")[-1]}\n\n']
+    title_frontmatter = f'title: {page_info.full_name.split(".")[-1]}'
+
+    parts  = []
+    parts.append(title_frontmatter) 
+
+    parts.append("\n\n")
 
     # Add the github button.
     parts.append(_top_source_link(page_info.defined_in))
@@ -413,8 +424,13 @@ def _build_module_page(page_info: parser.ModulePageInfo) -> str:
     Returns:
       The module markdown page.
     """
+    
+    title_frontmatter = f'title: {page_info.full_name.split(".")[-1]}'
+    
+    parts  = []
+    parts.append(title_frontmatter) 
 
-    parts = [f'# {page_info.full_name.split(".")[-1]}\n\n']
+    parts.append("\n\n")
 
     parts.append("<!-- Insert buttons and diff -->\n")
 
@@ -533,39 +549,15 @@ def _build_signature(
     return "".join(parts)
 
 
-TABLE_HEADER = (
-    # '<table class="tfo-notebook-buttons tfo-api nocontent" align="left">'
-    ""
-)
-
 _TABLE_TEMPLATE = textwrap.dedent(
     """
-    {table_header}
     {table_content}
-
     {table_footer}"""
 )
 
-# _TABLE_LINK_TEMPLATE = (
-#     "[![](https://www.tensorflow.org/images/GitHub-Mark-32px.png)"
-#     " View source on GitHub]({url})"
-# )
 
 _TABLE_LINK_TEMPLATE = (
-    "<p>"
-    "<button style={{{{display: 'flex', alignItems: 'center', "
-    "backgroundColor: 'white', border: '1px solid #ddd', padding: '10px', "
-    "borderRadius: '6px', cursor: 'pointer', "
-    "boxShadow: '0 2px 3px rgba(0,0,0,0.1)', transition: 'all 0.3s'}}}}>"
-    "<a href='{url}' style={{{{fontSize: '1.2em', "
-    "display: 'flex', alignItems: 'center'}}}}>"
-    "<img "
-    "src='https://github.githubassets.com/images/modules/logos_page/GitHub-Mark.png'"
-    " height='32px' width='32px' style={{{{marginRight: '10px'}}}}/>"
-    "View source on GitHub"
-    "</a>"
-    "</button>"
-    "</p>"
+    '{{< cta-button githubLink="{url}" >}}'
 )
 
 
@@ -582,7 +574,6 @@ def _top_source_link(location):
             table_content = _TABLE_LINK_TEMPLATE.format(url=location.url)
 
     table = _TABLE_TEMPLATE.format(
-        table_header=TABLE_HEADER,
         table_content=table_content,
         table_footer=table_footer,
     )

--- a/generate.py
+++ b/generate.py
@@ -60,6 +60,9 @@ def main(args):
     # clean up the file names
     clean_names(ref_dir)
 
+    # Fix frontmatter
+    reformat_title_to_frontmatter(ref_dir)
+
 
 def rename_to_readme(directory):
     """Moves all folder-level markdown files into respective folders, as a README."""
@@ -89,6 +92,28 @@ def clean_names(directory):
                 os.path.join(f"{root}", f"{name}"),
                 os.path.join(f"{root}", f"{short_name}"),
             )
+
+
+def reformat_title_to_frontmatter(directory):
+    "Fixes the title in the frontmatter of markdown files. Required for Hugo."
+ 
+    for root, _, files in os.walk(directory):
+        for file in files:
+            if file.endswith(".md"):  # Only process markdown files
+                file_path = os.path.join(root, file)
+
+                with open(file_path, "r", encoding="utf-8") as f:
+                    lines = f.readlines()
+
+                if lines and lines[0].startswith("title:"):
+                    # Reformat to markdown frontmatter
+                    frontmatter = f"---\n{lines[0].strip()}\n---\n"
+
+                    # Write back to the file with the updated format
+                    with open(file_path, "w", encoding="utf-8") as f:
+                        f.write(frontmatter)
+                        f.writelines(lines[1:])  # Write the rest of the file
+
 
 
 def single_folder_format(directory):


### PR DESCRIPTION
Updates docugen code so it renders markdown properly in Hugo.  This included frontmatter and CTA buttons.

Note: I added a silly function called `reformat_title_to_frontmatter` as a workaround to [this object rendering content into markdown](https://github.com/wandb/docugen/blob/bd6eaa9284d81d524e5af3c868e12478a2015f82/docugen/generate.py#L270).

Which means I can't [format this string](https://github.com/wandb/docugen/blob/bd6eaa9284d81d524e5af3c868e12478a2015f82/docugen/pretty_docs.py#L221) to include three dashes (---) without it being converted to pound signs.