### PR TITLE
Update output file of docugen

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -98,7 +98,7 @@ runs:
         git remote set-url origin https://${{ inputs.access-token }}@github.com/wandb/docodile.git ; \
         git pull origin main
         git reset --hard origin/main
-        cp -r ${{ github.action_path }}/ref ./docs/
+        cp -r ${{ github.action_path }}/ref ./docs/content/ref/
         if [[ `git status --porcelain` ]]; then
           git checkout -b sdk-${{ inputs.wandb-branch }} ; \
           git add -A .


### PR DESCRIPTION
Reference guide in Hugo is located in wandb/docs/content/ref/, not wandb/docs/ . This PR (hopefully) fixes where docugen stores the file when it creates the pull request