### PR TITLE
chore: add automations to generated docs

### DIFF
--- a/config.ini
+++ b/config.ini
@@ -15,6 +15,7 @@ integrations=Integrations
 launch=Launch
 keras=Keras
 weave=Weave
+automations=Automations
 
 [SKIPS]
 # subdirectories of ref/ to skip when creating table of contents/SUMMARY.md
@@ -46,7 +47,7 @@ module-doc-from=other.module.with.dunderdoc
 
 [SUBCONFIGS]
 # add your subconfig's name here to document a new module
-names=WANDB_CORE,WANDB_DATATYPES,WANDB_API,WANDB_INTEGRATIONS,WANDB_LAUNCH
+names=WANDB_CORE,WANDB_DATATYPES,WANDB_API,WANDB_INTEGRATIONS,WANDB_LAUNCH,WANDB_AUTOMATIONS
 
 [WANDB_CORE]
 # main python SDK library
@@ -90,7 +91,6 @@ add-from=
 add-elements=ValidationDataLogger
 module-doc-from=
 
-
 [WANDB_LAUNCH]
 # launch ref code
 dirname=launch-library
@@ -101,3 +101,12 @@ add-from=wandb.sdk.launch
 add-elements=launch,launch_add,LaunchAgent
 module-doc-from=
 
+[WANDB_AUTOMATIONS]
+# automations ref code
+dirname=automations
+title=Automations
+slug=wandb.automations.
+elements=
+add-from=automations
+add-elements=Automation,NewAutomation,OnAddArtifactAlias,OnCreateArtifact,OnLinkArtifact,OnRunMetric,MetricThresholdFilter,MetricChangeFilter,SendNotification,SendWebhook,DoNothing
+module-doc-from=

--- a/docugen/doc_generator_visitor.py
+++ b/docugen/doc_generator_visitor.py
@@ -2,7 +2,6 @@
 
 import collections
 import inspect
-
 from typing import Any, Dict, List, Optional, Tuple
 
 ApiPath = Tuple[str, ...]
@@ -30,7 +29,7 @@ def maybe_singleton(py_object: Any) -> bool:
     is_immutable_type = isinstance(py_object, immutable_types)
 
     # Check if the object is the empty tuple.
-    return is_immutable_type or py_object == ()
+    return is_immutable_type or (isinstance(py_object, tuple) and py_object == ())
 
 
 class ApiTreeNode(object):

--- a/docugen/generate.py
+++ b/docugen/generate.py
@@ -5,18 +5,12 @@ import pathlib
 import re
 import shutil
 import tempfile
-
 from typing import Any, Dict, List, Optional, Sequence, Tuple, Type, Union
 
 import mistune
 from mistune.renderers.markdown import MarkdownRenderer
 
-from docugen import doc_generator_visitor
-from docugen import parser
-from docugen import pretty_docs
-from docugen import public_api
-from docugen import traverse
-
+from docugen import doc_generator_visitor, parser, pretty_docs, public_api, traverse
 
 EXCLUDED = {"__init__.py", "OWNERS", "README.txt"}
 
@@ -166,11 +160,7 @@ class DocGenerator:
             root_module_name=self._short_name.replace(".", "/"),
         )
 
-        try:
-            os.makedirs(output_dir)
-        except OSError as e:
-            if e.strerror != "File exists":
-                raise
+        os.makedirs(output_dir, exist_ok=True)
 
         # Typical results are something like:
         #
@@ -261,9 +251,9 @@ class DocGenerator:
 
             # Clean up markdown and remove characters that break Docusuarus
             dictionary = {
-                "\_": "_",
-                "\*": "*",
-                "\*\*": "**",
+                "\\_": "_",
+                "\\*": "*",
+                "\\*\\*": "**",
                 "&quot;": '"',
             }
 

--- a/docugen/pretty_docs.py
+++ b/docugen/pretty_docs.py
@@ -5,11 +5,9 @@ necessary to document an element of a Python API.
 """
 
 import textwrap
+from typing import Dict, List, NamedTuple, Optional
 
-from typing import Dict, List, Optional, NamedTuple
-
-from docugen import doc_controls
-from docugen import parser
+from docugen import doc_controls, parser
 
 _TABLE_ITEMS = ("arg", "return", "raise", "attr", "yield")
 

--- a/generate.py
+++ b/generate.py
@@ -8,15 +8,13 @@ python generate.py --help
 """
 import argparse
 import os
+import re
 import shutil
 
 import wandb
 
 import cli
 import library
-
-import re
-
 
 # Replace auto-generated title as a key, provide the preferred title as the value
 # Note: This is replaced by Hugo. Future, remove this and function that calls it.

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,6 @@ mistune
 
 # for integrations
 tensorflow
+
+# for pydantic
+pydantic>=2.0,<3.0

--- a/util.py
+++ b/util.py
@@ -1,9 +1,21 @@
-def process_subconfigs(config, subconfig_names):
+from __future__ import annotations
+
+from typing import Any, Iterable
+
+
+def process_subconfigs(config, subconfig_names: Iterable[str]) -> list[dict[str, Any]]:
     """Applies some processing logic to config entries."""
     subconfigs = []
     for name in subconfig_names:
         subconfig = dict(config[name])
-        subconfig["add-elements"] = subconfig["add-elements"].split(",")
-        subconfig["elements"] = subconfig["elements"].split(",")
+
+        # If add-elements is empty, keep the list empty instead of setting it to `[""]`
+        add_elements = subconfig["add-elements"].split(",")
+        subconfig["add-elements"] = [s for s in map(str.strip, add_elements) if s]
+
+        # If elements is empty, keep the list empty instead of setting it to `[""]`
+        elements = subconfig["elements"].split(",")
+        subconfig["elements"] = [s for s in map(str.strip, elements) if s]
+
         subconfigs.append(subconfig)
     return subconfigs


### PR DESCRIPTION
~~NOTE: Do not merge until Automations API changes are merged, from:** https://github.com/wandb/wandb/pull/9246~~ (EDIT: already merged)

### Summary

- Adds exported items in `wandb.automations` namespace to generated API docs.
- Adds partial support for generating class docs from Pydantic types
- Misc autoformatting/minor fixes

### Screenshots

<img width="1102" alt="image" src="https://github.com/user-attachments/assets/a2656e3e-c9fc-4454-b51a-b30ad802ca07" />

<img width="1100" alt="image" src="https://github.com/user-attachments/assets/d886aa08-9107-4989-90ba-ac3d8245713e" />
